### PR TITLE
Changes in settings.py file

### DIFF
--- a/nomad/settings.py
+++ b/nomad/settings.py
@@ -38,7 +38,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
-    'rest_framework.authtoken'
+    'rest_framework.authtoken',
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
Added a missing comma in the group of app names in installed_apps in the settings.py file in the nomad directory after the name of the last app : 'rest_framework.authtoken'