### PR TITLE
fix #60 mark a notification and all notifications as read

### DIFF
--- a/api/modules/notification/views.py
+++ b/api/modules/notification/views.py
@@ -1,3 +1,4 @@
+from rest_framework import status
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
@@ -38,3 +39,39 @@ def get_notifications(request):
     notifications = Notification.objects.filter(destined_user=request.user).order_by('-created_at')
     serializer = NotificationSerializer(notifications, many=True)
     return Response(serializer.data)
+
+
+@api_view(['GET'])
+def mark_notification_as_read(request, notification_id):
+    """
+    Mark notification as read
+    :param request:
+    :param notification_id:
+    :return 200 successful
+    """
+    try:
+        notification = Notification.objects.get(id=notification_id)
+        if request.user != notification.destined_user:
+            return Response(status=status.HTTP_401_UNAUTHORIZED)
+        notification.is_read = True
+        notification.save()
+
+    except Notification.DoesNotExist:
+        error_message = "Notification does not exist"
+        return Response(error_message, status=status.HTTP_404_NOT_FOUND)
+
+    success_message = "Successfully marked notification as read."
+    return Response(success_message, status=status.HTTP_200_OK)
+
+
+@api_view(['GET'])
+def mark_all_notification_as_read(request):
+    """
+    Mark all notification as read
+    :param request:
+    :return 200 successful
+    """
+    notifications = Notification.objects.filter(destined_user=request.user)
+    notifications.update(is_read=True)
+    success_message = "Successfully marked all notifications as read."
+    return Response(success_message, status=status.HTTP_200_OK)

--- a/api/urls.py
+++ b/api/urls.py
@@ -50,6 +50,12 @@ urlpatterns = [
 
     # Notification
     path('get-notifications', notification_views.get_notifications, name="get-notifications"),
+    path('mark-notification/<int:notification_id>',
+         notification_views.mark_notification_as_read,
+         name="mark-notification"),
+    path('mark-all-notification',
+         notification_views.mark_all_notification_as_read,
+         name="mark-all-notification"),
 
     # Feedback
     path('add-feedback', feedback_views.add_feedback, name="add-feedback"),


### PR DESCRIPTION
# Description

It marks a single notification as well as all notification as read by changing `is_read` field to `true`

Fixes #60 

## Type of change
Just put an x in the [] which are valid.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `flake8`
- [ ] `python manage.py test`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
