### PR TITLE
fix #86, api to return common trips

### DIFF
--- a/api/modules/trips/views.py
+++ b/api/modules/trips/views.py
@@ -177,3 +177,31 @@ def update_trip_name(request, trip_id, trip_name):
         return Response(str(e), status=status.HTTP_400_BAD_REQUEST)
 
     return Response(status=status.HTTP_200_OK)
+
+
+@api_view(['GET'])
+def get_common_trips(request, user_id):
+    """
+    Common trips with a given friend
+    :param request:
+    :param user_id:
+    :return: 400 if user_id and request.user are same
+    :return: 404 if user with user_id does not exist
+    :return: 200 successful
+    """
+    # if user with user_id does not exist
+    if not User.objects.filter(id=user_id).exists():
+        error_message = "User does not exists."
+        return Response(error_message, status=status.HTTP_404_NOT_FOUND)
+
+    # if user_id is same as of request.user
+    if user_id == request.user.id:
+        error_message = "Requested user and logged in user are same."
+        return Response(error_message, status=status.HTTP_400_BAD_REQUEST)
+
+    common_trips = Trip.objects\
+        .filter(users=request.user)\
+        .filter(users=user_id)
+    serializer = TripSerializer(common_trips, many=True)
+
+    return Response(serializer.data, status=status.HTTP_200_OK)

--- a/api/urls.py
+++ b/api/urls.py
@@ -56,6 +56,7 @@ urlpatterns = [
          name="remove-friend-from-trip"),
     path('update-trip-name/<int:trip_id>/<str:trip_name>', trip_views.update_trip_name, name="update-trip-name"),
     path('trip-friends-all', user_views.trip_friends_all, name="trip-friends-all"),
+    path('get-common-trips/<int:user_id>', trip_views.get_common_trips, name="get-common-trips"),
 
     # Notification
     path('get-notifications', notification_views.get_notifications, name="get-notifications"),


### PR DESCRIPTION
# Description

return the list of common trips between logged in user and request friend. In case if requested user_id does not exists it returns 404 response. And if requested user_id is same as logged in user then returns 400 response.

Fixes #86 

## Type of change
Just put an x in the [] which are valid.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `flake8`
- [x] `python manage.py test`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
