### PR TITLE
fix #92, return empty array on invalid shopping query

### DIFF
--- a/api/modules/shopping/views.py
+++ b/api/modules/shopping/views.py
@@ -28,6 +28,10 @@ def get_shopping_info(request, query):
             error_message = api_response_json['errorMessage'][0]['error'][0]['message'][0]
             return Response(error_message, status=status.HTTP_503_SERVICE_UNAVAILABLE)
 
+        #  if ebay api returns empty response with no items
+        if api_response_json['findItemsAdvancedResponse'][0]['searchResult'][0]['@count'] == '0':
+            return Response([], status=status.HTTP_400_BAD_REQUEST)
+
         response = []
         for item in api_response_json['findItemsAdvancedResponse'][0]['searchResult'][0]['item']:
             response.append(ShoppingItem(


### PR DESCRIPTION
# Description

return a empty JSON array when an invalid shopping query is made to ebay API. If api response returns `@count` as 0 it returns empty array in response. In other cases API functions as usual.
Fixes #92

## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `flake8`
- [x] `python manage.py test`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
