### PR TITLE
Anonymous users can use forgot password feature

### DIFF
--- a/api/modules/users/views.py
+++ b/api/modules/users/views.py
@@ -320,8 +320,6 @@ def forgot_password_email_code(request, username):
         return Response(error_message, status=status.HTTP_404_NOT_FOUND)
 
 
-
-
 @api_view(['GET'])
 @permission_classes((AllowAny,))
 def forgot_password_verify_code(request, username, code, new_password):
@@ -336,6 +334,7 @@ def forgot_password_verify_code(request, username, code, new_password):
     :return: 200 successful
     """
     try:
+        # check if user with given username exists
         user = User.objects.get(username=username)
         try:
             pass_ver = PasswordVerification.objects.get(user=user)
@@ -360,7 +359,6 @@ def forgot_password_verify_code(request, username, code, new_password):
     except User.DoesNotExist:
         error_message = "Invalid username"
         return Response(error_message, status=status.HTTP_404_NOT_FOUND)
-
 
 
 @api_view(['GET'])

--- a/api/modules/users/views.py
+++ b/api/modules/users/views.py
@@ -28,6 +28,7 @@ def sign_up(request):
     :return: 400 if incorrect parameters are sent or email ID already exists
     :return: 201 successful
     """
+
     firstname = request.POST.get('firstname', None)
     lastname = request.POST.get('lastname', None)
     username = parseaddr(request.POST.get('email', None))[1].lower()
@@ -273,71 +274,93 @@ def update_password(request):
 
 
 @api_view(['GET'])
-def forgot_password_email_code(request):
+@permission_classes((AllowAny,))
+def forgot_password_email_code(request, username):
     """
     create and send email containing code for forgot password
     :param request:
+    :param username: email to identify the user
     :return: 400 if code generation or email sending fails
+    :return: 404 if invalid username
     :return: 200 successful
     """
     # generating/retrieving code
     try:
-        # if code already exists
-        pass_ver = PasswordVerification.objects.get(user=request.user)
-        code = pass_ver.code
+        # check if user with given username exists
+        user = User.objects.get(username=username)
+        try:
+            # if code already exists
+            pass_ver = PasswordVerification.objects.get(user=user)
+            code = pass_ver.code
 
-    except PasswordVerification.DoesNotExist:
-        # generate and save new code
-        code = generate_random_code()
-        pass_ver = PasswordVerification(user=request.user, code=code)
-        pass_ver.save()
+        except PasswordVerification.DoesNotExist:
+            # generate and save new code
+            code = generate_random_code()
+            pass_ver = PasswordVerification(user=user, code=code)
+            pass_ver.save()
 
-    except Exception as e:
-        return Response(str(e), status=status.HTTP_400_BAD_REQUEST)
+        except Exception as e:
+            return Response(str(e), status=status.HTTP_400_BAD_REQUEST)
 
-    # sending code via email
-    try:
-        to_list = [request.user.username]
-        fullname = "{} {}".format(request.user.first_name, request.user.last_name)
-        mail_subject = FORGOT_PASSWORD_MAIL_SUBJECT
-        mail_content = FORGOT_PASSWORD_MAIL_CONTENT.format(fullname, code)
-        send_mail(mail_subject, mail_content, DEFAULT_EMAIL_SENDER, to_list, fail_silently=False)
-    except SMTPException as e:
-        error_message = "Unable to send a forgot password email to user"
-        return Response(error_message, status=status.HTTP_400_BAD_REQUEST)
+        # sending code via email
+        try:
+            to_list = [user.username]
+            fullname = "{} {}".format(user.first_name, user.last_name)
+            mail_subject = FORGOT_PASSWORD_MAIL_SUBJECT
+            mail_content = FORGOT_PASSWORD_MAIL_CONTENT.format(fullname, code)
+            send_mail(mail_subject, mail_content, DEFAULT_EMAIL_SENDER, to_list, fail_silently=False)
+        except SMTPException as e:
+            error_message = "Unable to send a forgot password email to user"
+            return Response(error_message, status=status.HTTP_400_BAD_REQUEST)
 
-    return Response("Email sent", status=status.HTTP_200_OK)
+        return Response("Email sent", status=status.HTTP_200_OK)
+
+    except User.DoesNotExist:
+        error_message = "Invalid username"
+        return Response(error_message, status=status.HTTP_404_NOT_FOUND)
+
+
 
 
 @api_view(['GET'])
-def forgot_password_verify_code(request, code, new_password):
+@permission_classes((AllowAny,))
+def forgot_password_verify_code(request, username, code, new_password):
     """
     Updates password after verification of code and new password
     :param request:
+    :param username: email to identify the user
     :param code: 4 digit code received over mail
     :param new_password:
     :return: 400 if code generation fails
+    :return: 404 if invalid username
     :return: 200 successful
     """
     try:
-        pass_ver = PasswordVerification.objects.get(user=request.user)
-        if code == pass_ver.code:
-            if validate_password(new_password):
-                request.user.set_password(new_password)
-                request.user.save()
-                pass_ver.delete()
+        user = User.objects.get(username=username)
+        try:
+            pass_ver = PasswordVerification.objects.get(user=user)
+            if code == pass_ver.code:
+                if validate_password(new_password):
+                    user.set_password(new_password)
+                    user.save()
+                    pass_ver.delete()
+                else:
+                    return Response("Invalid new password", status=status.HTTP_400_BAD_REQUEST)
             else:
-                return Response("Invalid new password", status=status.HTTP_400_BAD_REQUEST)
-        else:
-            return Response("Code mismatch", status=status.HTTP_400_BAD_REQUEST)
+                return Response("Code mismatch", status=status.HTTP_400_BAD_REQUEST)
 
-    except PasswordVerification.DoesNotExist:
-        return Response("Forgot password code not yet generated", status=status.HTTP_400_BAD_REQUEST)
+        except PasswordVerification.DoesNotExist:
+            return Response("Forgot password code not yet generated", status=status.HTTP_400_BAD_REQUEST)
 
-    except Exception as e:
-        return Response(str(e), status=status.HTTP_400_BAD_REQUEST)
+        except Exception as e:
+            return Response(str(e), status=status.HTTP_400_BAD_REQUEST)
 
-    return Response("Password updated succesfully", status=status.HTTP_200_OK)
+        return Response("Password updated succesfully", status=status.HTTP_200_OK)
+
+    except User.DoesNotExist:
+        error_message = "Invalid username"
+        return Response(error_message, status=status.HTTP_404_NOT_FOUND)
+
 
 
 @api_view(['GET'])

--- a/api/urls.py
+++ b/api/urls.py
@@ -32,8 +32,8 @@ urlpatterns = [
     path('update-password', user_views.update_password, name='update-password'),
     path('remove-profile-image', user_views.remove_profile_image, name='remove-profile-image'),
     path('remove-user-status', user_views.remove_user_status, name='remove-user-status'),
-    path('forgot-password-email-code', user_views.forgot_password_email_code, name='forgot-password-email-code'),
-    path('forgot-password-verify-code/<str:code>/<str:new_password>', user_views.forgot_password_verify_code,
+    path('forgot-password-email-code/<str:username>', user_views.forgot_password_email_code, name='forgot-password-email-code'),
+    path('forgot-password-verify-code/<str:username>/<str:code>/<str:new_password>', user_views.forgot_password_verify_code,
          name='forgot-password-verify-code-code'),
     path('delete-profile', user_views.delete_profile, name='delete-profile'),
 

--- a/api/urls.py
+++ b/api/urls.py
@@ -32,9 +32,10 @@ urlpatterns = [
     path('update-password', user_views.update_password, name='update-password'),
     path('remove-profile-image', user_views.remove_profile_image, name='remove-profile-image'),
     path('remove-user-status', user_views.remove_user_status, name='remove-user-status'),
-    path('forgot-password-email-code/<str:username>', user_views.forgot_password_email_code, name='forgot-password-email-code'),
-    path('forgot-password-verify-code/<str:username>/<str:code>/<str:new_password>', user_views.forgot_password_verify_code,
-         name='forgot-password-verify-code-code'),
+    path('forgot-password-email-code/<str:username>', user_views.forgot_password_email_code,
+         name='forgot-password-email-code'),
+    path('forgot-password-verify-code/<str:username>/<str:code>/<str:new_password>',
+         user_views.forgot_password_verify_code, name='forgot-password-verify-code-code'),
     path('delete-profile', user_views.delete_profile, name='delete-profile'),
 
     # City APIs


### PR DESCRIPTION
# Description

Bug fix. Currently forgot password method is extracting the username from the request variable, which makes impossible to change the password for non-logged users. Adding a username parameter in GET request to identify the user even if not logged.

Fixes #137 

Screenshots for reference.

##### User details page:

<img width="1320" alt="screen shot 2018-10-08 at 3 09 56 am" src="https://user-images.githubusercontent.com/17281037/46587611-9652e200-caac-11e8-86b0-70683acfe99a.png">

##### Forgot password request with username in the url

<img width="1240" alt="screen shot 2018-10-08 at 3 11 19 am" src="https://user-images.githubusercontent.com/17281037/46587649-f2b60180-caac-11e8-95f9-aea41223df44.png">

##### Generated code for the requested user

<img width="562" alt="screen shot 2018-10-08 at 3 13 11 am" src="https://user-images.githubusercontent.com/17281037/46587657-1d07bf00-caad-11e8-8abe-b0d520b18d46.png">

##### Verify code request with username, code and password in url

<img width="1184" alt="screen shot 2018-10-08 at 3 20 43 am" src="https://user-images.githubusercontent.com/17281037/46587668-3ad52400-caad-11e8-880f-8a9e3bfc6a89.png">

## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `flake8`
- [x] `python manage.py test`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
