### PR TITLE
Add generate-verification-code API endpoint

### DIFF
--- a/api/modules/email/templates.py
+++ b/api/modules/email/templates.py
@@ -23,3 +23,11 @@ Dear {0},
 You have requested a password reset for your travel mate account. Use code {1} to reset your password.
 If you didn't make this request, ignore this email.
 """ + EMAIL_SIGNATURE
+
+# Verification code mails
+VERIFICATION_CODE_MAIL_SUBJECT = "Travel Mate - Your Verification Code"
+VERIFICATION_CODE_MAIL_CONTENT = """
+Dear {0},
+
+Your verification code: {1}
+""" + EMAIL_SIGNATURE

--- a/api/modules/users/views.py
+++ b/api/modules/users/views.py
@@ -3,6 +3,7 @@ from smtplib import SMTPException
 
 from django.contrib.auth.models import User
 from django.core.mail import send_mail
+from django.utils import timezone
 from rest_framework import status
 from rest_framework.decorators import permission_classes, api_view
 from rest_framework.permissions import AllowAny
@@ -401,7 +402,9 @@ def generate_verification_code(request):
     :return: 200 successful
     """
     code = generate_random_code(6)
-    # Update model to save the generated code
+    created_at = timezone.now()
+    pass_ver, _ = PasswordVerification.objects.update_or_create(
+        user=request.user, defaults={"code": code, "created": created_at})
     try:
         to_list = [request.user.username]
         fullname = "{} {}".format(request.user.first_name, request.user.last_name).title()
@@ -411,4 +414,4 @@ def generate_verification_code(request):
     except SMTPException as e:
         error_message = "Unable to send verification code email to user"
         return Response(error_message, status=status.HTTP_400_BAD_REQUEST)
-    return Response(code, status=status.HTTP_200_OK)
+    return Response("Verification code sent", status=status.HTTP_200_OK)

--- a/api/urls.py
+++ b/api/urls.py
@@ -38,6 +38,7 @@ urlpatterns = [
     path('forgot-password-verify-code/<str:username>/<str:code>/<str:new_password>',
          user_views.forgot_password_verify_code, name='forgot-password-verify-code-code'),
     path('delete-profile', user_views.delete_profile, name='delete-profile'),
+    path('generate-verification-code', user_views.generate_verification_code, name='generate-verification-code'),
 
     # City APIs
     path('get-all-cities', city_views.get_all_cities, name='get-all-cities'),


### PR DESCRIPTION
# Description

Created an API endpoint `generate-verification-code` which will created a new 6-digit verification code for the user and send that to his/her email. The new code will reflect also on the `PasswordVerification` instance.

Fixes #143 

## Type of change
Just put an x in the [] which are valid.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [X] `flake8`
- [ ] `python manage.py test`

# Checklist:
- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
