### PR TITLE
changed from psycopg2==2.7.4 to psycopg2-binary==2.7.7 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ gunicorn==19.8.1
 idna==2.6
 mccabe==0.6.1
 oauthlib==2.1.0
-psycopg2==2.7.4
+psycopg2-binary==2.7.7
 pycodestyle==2.3.1
 pyflakes==1.6.0
 pytz==2018.4


### PR DESCRIPTION

modified requirements.txt: changed psycopg2==2.7.4 to psycopg2-binary==2.7.7 in requirements.txt as the installation process was generating a warning of library being outdated

# Description
Fixes #158
