### PR TITLE
Fix #160 Add verified users count to Analytics API

### DIFF
--- a/api/modules/analytics/views.py
+++ b/api/modules/analytics/views.py
@@ -17,12 +17,16 @@ def get_total_users(request):
     :return: 200 successful
     """
     number_of_users = User.objects.count()
+    number_of_verified_users = User.objects.filter(profile__is_verified=True).count()
     end_date = datetime.now(tz=TIME_ZONE_SUBCLASS)
     start_date = end_date - timedelta(days=NUMBER_OF_DAYS_FOR_ACTIVE_STATUS)
     number_of_active_users = User.objects.filter(profile__last_active__range=[start_date, end_date]).count()
+    number_of_active_verified_users = User.objects.filter(profile__last_active__range=[start_date, end_date], profile__is_verified=True).count()
 
     res = {
         'total_users': number_of_users,
         'active_users': number_of_active_users,
+        'verified_users': number_of_verified_users,
+        'active_verified_users': number_of_active_verified_users
     }
     return Response(res, status=status.HTTP_200_OK)

--- a/api/modules/analytics/views.py
+++ b/api/modules/analytics/views.py
@@ -21,7 +21,8 @@ def get_total_users(request):
     end_date = datetime.now(tz=TIME_ZONE_SUBCLASS)
     start_date = end_date - timedelta(days=NUMBER_OF_DAYS_FOR_ACTIVE_STATUS)
     number_of_active_users = User.objects.filter(profile__last_active__range=[start_date, end_date]).count()
-    number_of_active_verified_users = User.objects.filter(profile__last_active__range=[start_date, end_date], profile__is_verified=True).count()
+    number_of_active_verified_users = User.objects.filter(
+            profile__last_active__range=[start_date, end_date], profile__is_verified=True).count()
 
     res = {
         'total_users': number_of_users,


### PR DESCRIPTION
# Description
Added two new responses to `get_total_users` API in `analytics`.
1. `verified_users`: Users who have **is_verified=True** in Profile
2. `active_verified_users`: User who are **verified_users** and were **active in the last 30 days**.

Fixes #160 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `flake8`
- [x] `python manage.py test`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
