### PR TITLE
Fix #191 Change return type for message when URL Validator fails

### DIFF
--- a/api/modules/admin/views.py
+++ b/api/modules/admin/views.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
@@ -31,6 +32,10 @@ def add_city_image(request):
         city = City.objects.get(pk=city_id)
         city_image = CityImage(city=city, image_url=image_url)
         city_image.save()
+    except ValidationError as e:
+        # e is a list of error messages
+        error_message = "\n".join(e)
+        return Response(error_message, status=status.HTTP_400_BAD_REQUEST)
     except Exception as e:
         error_message = str(e)
         return Response(error_message, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
# Description

Change return type for message when URL Validator fails

Fixes #191 

## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `flake8`
- [x] `python manage.py test`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
